### PR TITLE
imgaug: 0.2.9-patch

### DIFF
--- a/pkgs/development/python-modules/imgaug/default.nix
+++ b/pkgs/development/python-modules/imgaug/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, scikitimage, opencv3, six }:
+{ stdenv, buildPythonPackage, fetchPypi, numpy, scipy, scikitimage, opencv3, six, imageio, shapely }:
 
 buildPythonPackage rec {
   pname = "imgaug";
@@ -9,12 +9,21 @@ buildPythonPackage rec {
     sha256 = "42b0c4c8cbe197d4f5dbd33960a1140f8a0d9c22c0a8851306ecbbc032092de8";
   };
 
+  installPhase = ''
+    substituteInPlace requirements.txt \
+      --replace "opencv-python" "opencv>=3.4.7"
+    substituteInPlace setup.py \
+      --replace "opencv-python" "opencv>=3.4.7"
+  '';
+
   propagatedBuildInputs = [
     numpy
     scipy
     scikitimage
     opencv3
     six
+    imageio
+    shapely
   ];
 
   # disable tests when there are no tests in the PyPI archive
@@ -25,6 +34,5 @@ buildPythonPackage rec {
     description = "Image augmentation for machine learning experiments";
     license = licenses.mit;
     maintainers = with maintainers; [ cmcdragonkai ];
-    broken = true; # opencv-python bindings aren't available yet, and look non-trivial
   };
 }


### PR DESCRIPTION
Added patch to bypass opencv-python dependency from imgaug

@CMCDragonkai

<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
