### PR TITLE
pyhton3Packages.keras-tuner : init at 1.0.2

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8561,6 +8561,10 @@ in {
 
   vega = callPackage ../development/python-modules/vega { };
 
+  keras-preprocessing = callPackage ../development/python-modules/keras-preprocessing { };
+  
+  keras-tuner = callPackage ../development/python-modules/keras-tuner { };
+
   vega_datasets = callPackage ../development/python-modules/vega_datasets { };
 
   venstarcolortouch = callPackage ../development/python-modules/venstarcolortouch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8561,8 +8561,6 @@ in {
 
   vega = callPackage ../development/python-modules/vega { };
 
-  keras-preprocessing = callPackage ../development/python-modules/keras-preprocessing { };
-  
   keras-tuner = callPackage ../development/python-modules/keras-tuner { };
 
   vega_datasets = callPackage ../development/python-modules/vega_datasets { };

--- a/pkgs\development\python-modules\keras-tuner\default.nix
+++ b/pkgs\development\python-modules\keras-tuner\default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytest
+, colorama
+, scikitlearn
+, future
+, tqdm
+, scipy
+, requests
+, tabulate
+, terminaltables
+, tensorflow_2
+, tensorflow-tensorboard_2
+ }:
+ 
+buildPythonPackage rec {
+  pname = "keras-tuner";
+  version = "1.0.2";
+  
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "a9626842bc032bb0c8f3152bbc90910f50db3221f8aa980ec82ac729692707ec";
+  };
+  
+  propagatedBuildInputs = [ 
+    colorama
+	scikitlearn
+	future
+	tqdm
+	scipy
+	requests
+	tabulate
+	terminaltables
+  ];
+  checkInputs = [ 
+    pytest
+	tensorflow_2
+	tensorflow-tensorboard_2
+  ];
+  meta = {
+    homepage = "https://keras-team.github.io/keras-tuner";
+    description = "hyperparameter tuning for TensorFlow/Keras";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rakesh4g ];
+  };
+}


### PR DESCRIPTION
pyhton3Packages.keras-tuner : init at 1.0.2

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
